### PR TITLE
re-fit parameters for thickness to opacity function

### DIFF
--- a/auto_forge.py
+++ b/auto_forge.py
@@ -70,9 +70,9 @@ def composite_pixel_combined(pixel_height_logit, global_logits, tau_height, tau_
 
     # Parameters for opacity calculation.
 
-    A = 0.3489855138693261
-    k = 101.72142747530887
-    b = 0.9014283137171897
+    A = 0.178763
+    k = 39.302848
+    b = 0.351177
 
     def step_fn(carry, i):
         comp, remaining = carry


### PR DESCRIPTION
It appears that the function used for thickness of layers to opacity, used to calculate the resulting colors when blending filament, is not working as expected.  I ran a hueforge test using a simple gradient, mapped to a TD=10.0 white on black. I captured the values that it generated for the first 9 layers, converted those to opacity values, and then fit the function by adjusting  the (A, k, b) values with a random walk search.

![opacity](https://github.com/user-attachments/assets/87794304-3e2a-4753-a39c-907072fd4edc)
Here's the resulting function. X axis is the `thickness / 0.1*TD` and Y is the resulting opacity. It approaches opacity=1.0 when the thickness reaches `0.1*TD` as seems to be used in hueforge.

I'm seeing much better gradients/blending when I re-run my couple of photos as tests. 