### PR TITLE
Add `mps` backend support

### DIFF
--- a/src/autoforge/Helper/OptimizerHelper.py
+++ b/src/autoforge/Helper/OptimizerHelper.py
@@ -690,7 +690,7 @@ def init_height_map(target, max_layers, h, eps=1e-6, random_seed=None):
 
     new_labels = new_labels.astype(np.float32) / new_labels.max()
 
-    normalized_lum = np.array(new_labels, dtype=np.float64)
+    normalized_lum = np.array(new_labels, dtype=np.float32)
     # convert out to inverse sigmoid logit function
     pixel_height_logits = np.log((normalized_lum + eps) / (1 - normalized_lum + eps))
 

--- a/src/autoforge/auto_forge.py
+++ b/src/autoforge/auto_forge.py
@@ -156,10 +156,21 @@ def main():
         default=0.1,
         help="Slider (0 to 1) blending original luminance ordering (0) and depth-informed ordering (1).",
     )
+    parser.add_argument(
+        "--mps",
+        action="store_true",
+        help="Use the Metal Performance Shaders (MPS) backend, if available.",
+    )
 
     args = parser.parse_args()
 
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif args.mps and torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
     print("Using device:", device)
 
     os.makedirs(args.output_folder, exist_ok=True)

--- a/src/autoforge/auto_forge_gradio.py
+++ b/src/autoforge/auto_forge_gradio.py
@@ -60,7 +60,7 @@ def compute_initial_height_map(input_image, max_layers, layer_height):
     The height map is normalized to 0-255 for display.
     """
     # Convert the input image to a jax array (assumed to be RGB)
-    target = jnp.array(input_image, dtype=jnp.float64)
+    target = jnp.array(input_image, dtype=jnp.float32)
     height_map = init_height_map(target, max_layers, layer_height)
     height_map_np = np.array(height_map)
     # Normalize for display purposes.


### PR DESCRIPTION
This adds support for `mps` on macs, with `mps` disabled by default.

To make this work without errors, I had to use 32 bit floats for `normalized_lum`. I suspect that the extra precision isn't needed here (in fact, 32 bits feels like overkill?) but I'm an ML newbie, so let me know if I'm mistaken.

I found that `mps` is actually slower for this workload on my m4 max, but using it seems a lot more energy / heat efficient.

Here's a short run with `mps` disabled, followed by one with `mps` enabled, just to show the GPU get used.

<img width="1144" alt="image" src="https://github.com/user-attachments/assets/8c50e7fa-ac57-4b71-9a9f-3441523f0865" />

p.s. Really appreciate the switch to torch, was much easier to get Cuda going on my other machine.