### PR TITLE
Add optional TensorBoard output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# TensorBoard logs
+runs/
+
 # C extensions
 *.so
 

--- a/README.md
+++ b/README.md
@@ -91,8 +91,11 @@ autoforge --input_image path/to/input_image.jpg --csv_file path/to/materials.csv
 - `--output_size`: Maximum dimension for target image (default: 1024).
 - `--solver_size`: Maximum dimension for solver (fast) image (default: 128). \
   **Note:** We solve on a smaller size as this is many times faster, but also a bit less accurate. Increase if you need more accuracy.
-- `--decay`: Final tau value for the Gumbel-Softmax formulation (default: 0.01).
+- `--init_tau`: Initial tau value for Gumbel-Softmax (default: 1.0).
+- `--final_tau`: Final tau value for the Gumbel-Softmax formulation (default: 0.01).
 - `--visualize`: Flag to enable live visualization of the composite image during optimization.
+- `--tensorboard`: Enable TensorBoard logging
+- `--run-name`: Name of the run used for TensorBoard logging (optional).
 - `--perform_pruning`: Perform pruning after optimization (default: True). \
   **Note:** This is highly recommended even if you don't have a color/color swap limit, as it actually increases the quality of the output.
 - `--pruning_max_colors`: Max number of colors allowed after pruning (default: 100).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,8 @@ dependencies = [
   "tqdm>=4.50.0",
   "pandas>=1.1.0",
   "scikit-image",
-  "scikit-learn"
+  "scikit-learn",
+  "tensorboard"
 ]
 
 [tool.setuptools]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ tqdm>=4.50.0
 pandas>=1.1.0
 scikit-image
 scikit-learn
+tensorboard
+standard-imghdr

--- a/src/autoforge/auto_forge.py
+++ b/src/autoforge/auto_forge.py
@@ -86,10 +86,10 @@ def main():
         help="Maximum dimension for solver (fast) image",
     )
     parser.add_argument(
-        "--init_tau", type=float, default=0.2, help="Initial tau value for Gumbel-Softmax"
+        "--init_tau", type=float, default=1.0, help="Initial tau value for Gumbel-Softmax"
     )
     parser.add_argument(
-        "--final_tau", type=float, default=1.0, help="Final tau value for Gumbel-Softmax"
+        "--final_tau", type=float, default=0.2, help="Final tau value for Gumbel-Softmax"
     )
 
     parser.add_argument(

--- a/src/autoforge/auto_forge.py
+++ b/src/autoforge/auto_forge.py
@@ -89,7 +89,7 @@ def main():
         "--init_tau", type=float, default=1.0, help="Initial tau value for Gumbel-Softmax"
     )
     parser.add_argument(
-        "--final_tau", type=float, default=0.2, help="Final tau value for Gumbel-Softmax"
+        "--final_tau", type=float, default=0.01, help="Final tau value for Gumbel-Softmax"
     )
 
     parser.add_argument(


### PR DESCRIPTION
Closes #14 

Adds optional logging to [TensorBoard](https://www.tensorflow.org/tensorboard), controlled by the `--tensorboard` cli arg.

Nice run names can be set with, for example, `--run-name experiment1`.

Start tensorboard with `tensorboard --logdir=runs`.

Please feel free to use as much or as little of this as you wish, or I'm happy to work on it if you'd like changes.