### PR TITLE
Make it possible to disable visualization

### DIFF
--- a/src/autoforge/auto_forge.py
+++ b/src/autoforge/auto_forge.py
@@ -1,3 +1,4 @@
+import argparse
 import sys
 import os
 import time
@@ -120,6 +121,7 @@ def main():
         type=bool,
         default=True,
         help="Enable visualization during optimization",
+        action=argparse.BooleanOptionalAction,
     )
 
     # Instead of an output_size parameter, we use stl_output_size and nozzle_diameter.


### PR DESCRIPTION
It's currently not possible to invoke AutoForge without visualizations enabled. Or at least, I can't figure out how.

I tried `--visualize=False`, `--visualize=false`, `--visualize=0`, and others, and `args.visualize` is always `True`.

Python's not really my forte, but I dug up https://stackoverflow.com/questions/15008758/parsing-boolean-values-with-argparse which suggests this changeset.

After this change, `--no-visualize` is valid and disables visualization.

Feel free to close for an alternative solution.